### PR TITLE
修正设备制造商名字过长引起的Crash问题

### DIFF
--- a/boost_multidex/build.gradle
+++ b/boost_multidex/build.gradle
@@ -17,7 +17,7 @@ android {
 
         externalNativeBuild {
             cmake {
-                cppFlags "-std=c++14", "-fno-exceptions", "-O2"
+                cppFlags "-std=c++14", "-O2" //"-fno-exceptions",
                 abiFilters "armeabi", "armeabi-v7a", "x86"
             }
         }

--- a/boost_multidex/src/main/cpp/boost_multidex.cpp
+++ b/boost_multidex/src/main/cpp/boost_multidex.cpp
@@ -193,19 +193,23 @@ static func_openDexFileBytes findOpenDexFileFunc(JNINativeMethod *func, const ch
 }
 
 static bool CheckIsSpecHtc() {
-    const char htc[] = "htc";
-    size_t len = strlen(htc);
+    try{
+        const char htc[] = "htc";
+        size_t len = strlen(htc);
 
-    char brand[PROP_NAME_MAX];
-    __system_property_get("ro.product.brand", brand);
-    if (strncasecmp(htc, brand, len) == 0) {
-        return true;
+        char brand[PROP_NAME_MAX * 3];
+        __system_property_get("ro.product.brand", brand);
+        if (strncasecmp(htc, brand, len) == 0) {
+            return true;
+        }
+        __system_property_get("ro.product.manufacturer", brand);
+        if (strncasecmp(htc, brand, len) == 0) {
+            return true;
+        }
+        return false;
+    } catch (...) {
+        return false;
     }
-    __system_property_get("ro.product.manufacturer", brand);
-    if (strncasecmp(htc, brand, len) == 0) {
-        return true;
-    }
-    return false;
 }
 
 static void OpenDexHandler(int) {


### PR DESCRIPTION
在某些设备（比如机顶盒）上，因为制造商名字过长，导致CheckIsSpecHtc方法引起Crash：
修正方法：将brand字符数组长度扩大3倍，并将CheckIsSpecHtc进行异常捕获，避免该方法异常导致整个流程失败。